### PR TITLE
Prevent dragons from trying to catch their owner while on a leash.

### DIFF
--- a/src/main/java/info/ata4/minecraft/dragon/server/entity/ai/EntityAICatchOwner.java
+++ b/src/main/java/info/ata4/minecraft/dragon/server/entity/ai/EntityAICatchOwner.java
@@ -45,6 +45,11 @@ public class EntityAICatchOwner extends EntityAIBase {
             return false;
         }
         
+        // don't catch if leashed
+        if (dragon.getLeashed()) {
+            return false;
+        }
+        
         return owner.fallDistance > 4;
     }
 }


### PR DESCRIPTION
Some players find it quite annoying when their dragon flies/teleports to them when they deliberately fall (i.e. when using a safe drop into water, flying with a jetpack from another mod, etc) especially when this results in the dragon becoming trapped in a hard to access place (inside a house, mines, etc).

To alleviate this issue while preserving functionality for those who prefer or rely on this behavior, this patch modifies dragon behavior to prevent them from attempting to catch their owner while the dragon is on a leash, allowing players to tether their dragon to a fencepost to prevent it from teleporting to them when the owner falls.

This behavior is both intuitive (it makes sense that a creature shouldn't be able to break away from its leash for any reason) and unobtrusive (easy to do in game, without any GUI configs or other toggling of settings).